### PR TITLE
added non-free to sources.list

### DIFF
--- a/install/ersatztv-install.sh
+++ b/install/ersatztv-install.sh
@@ -21,6 +21,17 @@ $STD apt-get install -y sudo
 $STD apt-get install -y mc
 msg_ok "Installed Dependencies"
 
+msg_info "Setting Up Hardware Acceleration"
+$STD apt-get -y install {va-driver-all,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
+if [[ "$CTTYPE" == "0" ]]; then
+  chgrp video /dev/dri
+  chmod 755 /dev/dri
+  chmod 660 /dev/dri/*
+  $STD adduser $(id -u -n) video
+  $STD adduser $(id -u -n) render
+fi
+msg_ok "Set Up Hardware Acceleration"
+
 msg_info "Installing FFmpeg (Patience)"
 wget -q https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb
 $STD dpkg -i deb-multimedia-keyring_2016.8.1_all.deb
@@ -38,6 +49,11 @@ msg_info "Installing ErsatzTV"
 RELEASE=$(curl -s https://api.github.com/repos/ErsatzTV/ErsatzTV/releases | grep -oP '"tag_name": "\K[^"]+' | head -n 1)
 wget -qO- "https://github.com/ErsatzTV/ErsatzTV/releases/download/${RELEASE}/ErsatzTV-${RELEASE}-linux-x64.tar.gz" | tar -xz -C /opt
 mv "/opt/ErsatzTV-${RELEASE}-linux-x64" /opt/ErsatzTV
+if [[ "$CTTYPE" == "0" ]]; then
+  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:root,ersatztv/' -e 's/^render:x:108:root,ersatztv$/ssl-cert:x:108:/' /etc/group
+else
+  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:ersatztv/' -e 's/^render:x:108:ersatztv$/ssl-cert:x:108:/' /etc/group
+fi
 msg_ok "Installed ErsatzTV"
 
 msg_info "Creating Service"

--- a/install/ersatztv-install.sh
+++ b/install/ersatztv-install.sh
@@ -22,7 +22,20 @@ $STD apt-get install -y mc
 msg_ok "Installed Dependencies"
 
 msg_info "Setting Up Hardware Acceleration"
-$STD apt-get -y install {va-driver-all,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
+# Backup the original /etc/apt/sources.list
+cp /etc/apt/sources.list /etc/apt/sources.list.bak
+
+# Update /etc/apt/sources.list with new contents
+cat <<EOF > /etc/apt/sources.list
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free
+deb http://security.debian.org bookworm-security main contrib non-free
+EOF
+
+# Update package lists
+apt-get update
+
+$STD apt-get -y install {intel-media-va-driver-non-free,va-driver-all,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
 if [[ "$CTTYPE" == "0" ]]; then
   chgrp video /dev/dri
   chmod 755 /dev/dri
@@ -49,11 +62,6 @@ msg_info "Installing ErsatzTV"
 RELEASE=$(curl -s https://api.github.com/repos/ErsatzTV/ErsatzTV/releases | grep -oP '"tag_name": "\K[^"]+' | head -n 1)
 wget -qO- "https://github.com/ErsatzTV/ErsatzTV/releases/download/${RELEASE}/ErsatzTV-${RELEASE}-linux-x64.tar.gz" | tar -xz -C /opt
 mv "/opt/ErsatzTV-${RELEASE}-linux-x64" /opt/ErsatzTV
-if [[ "$CTTYPE" == "0" ]]; then
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:root,ersatztv/' -e 's/^render:x:108:root,ersatztv$/ssl-cert:x:108:/' /etc/group
-else
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:ersatztv/' -e 's/^render:x:108:ersatztv$/ssl-cert:x:108:/' /etc/group
-fi
 msg_ok "Installed ErsatzTV"
 
 msg_info "Creating Service"

--- a/misc/build.func
+++ b/misc/build.func
@@ -588,7 +588,7 @@ EOF
   fi
 
   if [ "$CT_TYPE" == "0" ]; then
-    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scrypted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" ]]; then
+    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scrypted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "ErsatzTV" ]]; then
       cat <<EOF >>$LXC_CONFIG
 # VAAPI hardware transcoding
 lxc.cgroup2.devices.allow: c 226:0 rwm
@@ -600,7 +600,7 @@ lxc.mount.entry: /dev/dri/renderD128 dev/dri/renderD128 none bind,optional,creat
 EOF
     fi
   else
-    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scrypted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" ]]; then
+    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scrypted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "ErsatzTV" ]]; then
       if [[ -e "/dev/dri/renderD128" ]]; then
         if [[ -e "/dev/dri/card0" ]]; then
           cat <<EOF >>$LXC_CONFIG


### PR DESCRIPTION
Added non-free to sources.list to be able to install intel-media-va-driver-non-free

## Description

- intel-media-va-driver-non-free was needed for transcoding (VAAPI driver for the Intel GEN8+ Graphics family)
- Also removed the sed portion of the script as it is not needed

## Type of change

Please check the relevant option(s):

- [x] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)

